### PR TITLE
Add Authorship & Contribution TF subpage

### DIFF
--- a/content/tf-authorship-contribution/10-tf-authorship-contribution-header/index.md
+++ b/content/tf-authorship-contribution/10-tf-authorship-contribution-header/index.md
@@ -1,0 +1,16 @@
++++
+fragment = "hero"
+#disabled = true
+date = "2023-11-17"
+weight = 10
+background = "black"
+particles = true
+
+title_page = false # Default is false
+title = "Research Software Authorship and Contribution Task Force"
+
+[header]
+  image = "main-hero.png"
+  text = "Main character"
+
++++

--- a/content/tf-authorship-contribution/20-content.md
+++ b/content/tf-authorship-contribution/20-content.md
@@ -1,0 +1,30 @@
++++
+fragment = "content"
+disabled = false
+date = "2023-11-17"
+weight = 20
+background = "white"
+
++++
+
+The task force builds on [previous work](https://sdruskat.net/software-authorship/) to define criteria for software authorship and describe contribution types/roles in software. It aims to address
+
+- a lack of community guidelines and criteria for software authorship;
+- a lack of community support for any one existing contribution taxonomy/vocabulary for software.
+
+Roadmap:
+
+1. Examine relevant previous work
+2. Draft definitions of software authorship and contributions
+3. Facilitate expert and community review and consultation
+4. Publish community guidelines
+
+The members of the task force are:
+
+- Carlos Martinez-Ortiz, Netherlands eScience Center, <https://orcid.org/0000-0001-5565-7577>
+- Deborah Leem, University College London (UCL), <https://orcid.org/0000-0002-5836-0899>
+- Gemma Turon Rodrigo, Fundació Ersilia Open Source Initiative, <https://orcid.org/0000-0001-6798-0275>  
+- Hugo Gruson, data.org, <https://orcid.org/0000-0002-4094-1476>
+- Neil Chue Hong, University of Edinburgh / Software Sustainability Institute, <https://orcid.org/0000-0002-8876-7606> 
+- Saranjeet Kaur Bhogal, Research Software Alliance, <https://orcid.org/0000-0002-7038-1457>
+- Stephan Druskat (chair), German Aerospace Center (DLR), <https://orcid.org/0000-0003-4925-7248>, [stephan.druskat@dlr.de](mailto:stephan.druskat@dlr.de)

--- a/content/tf-authorship-contribution/20-content.md
+++ b/content/tf-authorship-contribution/20-content.md
@@ -21,10 +21,10 @@ The task force builds on [previous work](https://sdruskat.net/software-authorshi
 
 ### Task Force Members
 
-- Carlos Martinez-Ortiz, Netherlands eScience Center, <https://orcid.org/0000-0001-5565-7577>
-- Deborah Leem, University College London (UCL), <https://orcid.org/0000-0002-5836-0899>
-- Gemma Turon Rodrigo, Fundació Ersilia Open Source Initiative, <https://orcid.org/0000-0001-6798-0275>  
-- Hugo Gruson, data.org, <https://orcid.org/0000-0002-4094-1476>
-- Neil Chue Hong, University of Edinburgh / Software Sustainability Institute, <https://orcid.org/0000-0002-8876-7606> 
-- Saranjeet Kaur Bhogal, Research Software Alliance, <https://orcid.org/0000-0002-7038-1457>
-- Stephan Druskat (chair), German Aerospace Center (DLR), <https://orcid.org/0000-0003-4925-7248>, [stephan.druskat@dlr.de](mailto:stephan.druskat@dlr.de)
+- *Carlos Martinez-Ortiz*, Netherlands eScience Center, <https://orcid.org/0000-0001-5565-7577>
+- *Deborah Leem*, University College London (UCL), <https://orcid.org/0000-0002-5836-0899>
+- *Gemma Turon Rodrigo*, Fundació Ersilia Open Source Initiative, <https://orcid.org/0000-0001-6798-0275>  
+- *Hugo Gruson*, data.org, <https://orcid.org/0000-0002-4094-1476>
+- *Neil Chue Hong*, University of Edinburgh / Software Sustainability Institute, <https://orcid.org/0000-0002-8876-7606> 
+- *Saranjeet Kaur Bhogal*, Research Software Alliance, <https://orcid.org/0000-0002-7038-1457>
+- *Stephan Druskat* (chair), German Aerospace Center (DLR), <https://orcid.org/0000-0003-4925-7248>, [stephan.druskat@dlr.de](mailto:stephan.druskat@dlr.de)

--- a/content/tf-authorship-contribution/20-content.md
+++ b/content/tf-authorship-contribution/20-content.md
@@ -12,14 +12,14 @@ The task force builds on [previous work](https://sdruskat.net/software-authorshi
 - a lack of community guidelines and criteria for software authorship;
 - a lack of community support for any one existing contribution taxonomy/vocabulary for software.
 
-Roadmap:
+### Roadmap
 
 1. Examine relevant previous work
 2. Draft definitions of software authorship and contributions
 3. Facilitate expert and community review and consultation
 4. Publish community guidelines
 
-The members of the task force are:
+### Task Force Members
 
 - Carlos Martinez-Ortiz, Netherlands eScience Center, <https://orcid.org/0000-0001-5565-7577>
 - Deborah Leem, University College London (UCL), <https://orcid.org/0000-0002-5836-0899>

--- a/content/tf-authorship-contribution/index.md
+++ b/content/tf-authorship-contribution/index.md
@@ -1,0 +1,4 @@
++++
+title = "Research Software Authorship and Contribution Task Force"
+date = "2023-11-17"
++++


### PR DESCRIPTION
This PR adds a subpage for the Research Software Authorship and Contribution Task Force.

This is done via Pull Request to see if the PR breaks nothing.