### PR TITLE
Closes #55 change blog list structure to single page structure

### DIFF
--- a/layouts/about-resa/list.html
+++ b/layouts/about-resa/list.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<section id="about-resa">
+    {{ range .Pages }}
+    <article>
+        <h2>{{ .Title }}</h2>
+        <div>{{ .Content }}</div>
+    </article>
+    {{ end }}
+</section>
+{{ end }}

--- a/layouts/community-forum/list.html
+++ b/layouts/community-forum/list.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<section id="funders-forum">
+    {{ range .Pages }}
+    <article>
+        <h2>{{ .Title }}</h2>
+        <div>{{ .Content }}</div>
+    </article>
+    {{ end }}
+</section>
+{{ end }}

--- a/layouts/donate/list.html
+++ b/layouts/donate/list.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<section id="donate">
+    {{ range .Pages }}
+    <article>
+        <h2>{{ .Title }}</h2>
+        <div>{{ .Content }}</div>
+    </article>
+    {{ end }}
+</section>
+{{ end }}

--- a/layouts/funders-forum/list.html
+++ b/layouts/funders-forum/list.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<section id="funders-forum">
+    {{ range .Pages }}
+    <article>
+        <h2>{{ .Title }}</h2>
+        <div>{{ .Content }}</div>
+    </article>
+    {{ end }}
+</section>
+{{ end }}

--- a/layouts/funding-opportunities/list.html
+++ b/layouts/funding-opportunities/list.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<section id="resa-resources">
+    {{ range .Pages }}
+    <article>
+        <h2>{{ .Title }}</h2>
+        <div>{{ .Content }}</div>
+    </article>
+    {{ end }}
+</section>
+{{ end }}

--- a/layouts/governance/list.html
+++ b/layouts/governance/list.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<section id="governance">
+    {{ range .Pages }}
+    <article>
+        <h2>{{ .Title }}</h2>
+        <div>{{ .Content }}</div>
+    </article>
+    {{ end }}
+</section>
+{{ end }}

--- a/layouts/guidelines/list.html
+++ b/layouts/guidelines/list.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<section id="resa-resources">
+    {{ range .Pages }}
+    <article>
+        <h2>{{ .Title }}</h2>
+        <div>{{ .Content }}</div>
+    </article>
+    {{ end }}
+</section>
+{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,8 @@
+{{ define "main" }}
+{{ range (where .Site.Pages "Section" "_index") }}
+<article>
+    <h1>{{ .Title }}</h1>
+    <div>{{ .Content }}</div>
+</article>
+{{ end }}
+{{ end }}

--- a/layouts/membership/list.html
+++ b/layouts/membership/list.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<section id="membership">
+    {{ range .Pages }}
+    <article>
+        <h2>{{ .Title }}</h2>
+        <div>{{ .Content }}</div>
+    </article>
+    {{ end }}
+</section>
+{{ end }}

--- a/layouts/people/list.html
+++ b/layouts/people/list.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<section id="people">
+    {{ range .Pages }}
+    <article>
+        <h2>{{ .Title }}</h2>
+        <div>{{ .Content }}</div>
+    </article>
+    {{ end }}
+</section>
+{{ end }}

--- a/layouts/resa-resources/list.html
+++ b/layouts/resa-resources/list.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<section id="resa-resources">
+    {{ range .Pages }}
+    <article>
+        <h2>{{ .Title }}</h2>
+        <div>{{ .Content }}</div>
+    </article>
+    {{ end }}
+</section>
+{{ end }}

--- a/layouts/research-software-engineers/list.html
+++ b/layouts/research-software-engineers/list.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<section id="resa-resources">
+    {{ range .Pages }}
+    <article>
+        <h2>{{ .Title }}</h2>
+        <div>{{ .Content }}</div>
+    </article>
+    {{ end }}
+</section>
+{{ end }}

--- a/layouts/rsi-forum/list.html
+++ b/layouts/rsi-forum/list.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<section id="funders-forum">
+    {{ range .Pages }}
+    <article>
+        <h2>{{ .Title }}</h2>
+        <div>{{ .Content }}</div>
+    </article>
+    {{ end }}
+</section>
+{{ end }}

--- a/layouts/software-policies/list.html
+++ b/layouts/software-policies/list.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<section id="resa-resources">
+    {{ range .Pages }}
+    <article>
+        <h2>{{ .Title }}</h2>
+        <div>{{ .Content }}</div>
+    </article>
+    {{ end }}
+</section>
+{{ end }}

--- a/layouts/taskforces/list.html
+++ b/layouts/taskforces/list.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<section id="taskforces">
+    {{ range .Pages }}
+    <article>
+        <h2>{{ .Title }}</h2>
+        <div>{{ .Content }}</div>
+    </article>
+    {{ end }}
+</section>
+{{ end }}

--- a/layouts/tf-support/list.html
+++ b/layouts/tf-support/list.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<section id="taskforces">
+    {{ range .Pages }}
+    <article>
+        <h2>{{ .Title }}</h2>
+        <div>{{ .Content }}</div>
+    </article>
+    {{ end }}
+</section>
+{{ end }}


### PR DESCRIPTION
In this PR, I have created `list.html` files in the different in the 'layouts/' folder of the root directory 'website/'.
Before this change, for each of the dropdown section About, Task Forces, Forums, and Resources, the content was rendered as a list of blogs. By adding the `list.html` files, the content is now rendered in one single page one below the other.

This closes issue #55 .