### PR TITLE
add necessary css code to render markdown tables #58

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,7 +5,7 @@ googleAnalytics = "UA-181241343-1"
 languageCode = "en-uk"
 LanguageCode = "en-uk"
 title = "Research Software Alliance"
-theme = "syna"
+theme = "ananke"
 enableGitInfo = true
 version = "0.17.3"
 rssLimit = 100
@@ -48,150 +48,156 @@ rssLimit = 100
   [params.colors]
     primary = "darkgreen"
     secondary = "darkorange"
+  customCSS = ["css/custom.css"]
 
-[[menu.main]]
-  identifier = "/about-resa"
-  name = "About"
-  weight = 10
+  homePage = true  # This is optional but makes it clear for your intent
 
-[[menu.main]]
-  parent = "/about-resa"
-  url = "/about-resa"
-  name = "About"
-  weight = 11
 
-[[menu.main]]
-    parent = "/about-resa"
-    url = "/governance"
-    name = "Governance"
-    weight = 12
+[menu]
 
-[[menu.main]]
-  parent = "/about-resa"
-  url = "/people"
-  name = "People"
-  weight = 13
+  [[menu.main]]
+    identifier = "/about-resa"
+    name = "About"
+    weight = 10
 
-[[menu.main]]
-  parent = "/about-resa"
-  url = "/membership"
-  name = "Organisational Membership"
-  weight = 14
+    [[menu.main]]
+      parent = "/about-resa"
+      url = "/about-resa"
+      name = "About"
+      weight = 11
 
-[[menu.main]]
-  parent = "/about-resa"
-  url = "/donate"
-  name = "Donate"
-  weight = 15
+    [[menu.main]]
+        parent = "/about-resa"
+        url = "/governance"
+        name = "Governance"
+        weight = 12
 
-[[menu.main]]
-  identifier = "/taskforces"
-  name = "Task Forces"
-  weight = 20
+    [[menu.main]]
+      parent = "/about-resa"
+      url = "/people"
+      name = "People"
+      weight = 13
 
-[[menu.main]]
-  parent = "/taskforces"
-  url = "/taskforces"
-  name = "About Task Forces"
-  weight = 21
+    [[menu.main]]
+      parent = "/about-resa"
+      url = "/membership"
+      name = "Organisational Membership"
+      weight = 14
 
- [[menu.main]]
-  parent = "/taskforces"
-  url = "/tf-support"
-  name = "Task Force Support"
-  weight = 22
+    [[menu.main]]
+      parent = "/about-resa"
+      url = "/donate"
+      name = "Donate"
+      weight = 15
 
-[[menu.main]]
-  identifier = "/forums"
-  name = "Forums"
-  weight = 30
+  [[menu.main]]
+    identifier = "/taskforces"
+    name = "Task Forces"
+    weight = 20
 
-[[menu.main]]
-  parent = "/forums"
-  url = "/funders-forum"
-  name = "Funders Forum"
-  weight = 31
+    [[menu.main]]
+      parent = "/taskforces"
+      url = "/taskforces"
+      name = "About Task Forces"
+      weight = 21
 
-[[menu.main]]
-  parent = "/forums"
-  url = "/RSI-forum"
-  name = "Research Software Infrastructure Forum"
-  weight = 32
+    [[menu.main]]
+      parent = "/taskforces"
+      url = "/tf-support"
+      name = "Task Force Support"
+      weight = 22
 
-[[menu.main]]
-  parent = "/forums"
-  url = "https://adore.software/"
-  name = "ADORE.software Secretariat"
-  weight = 33
+  [[menu.main]]
+    identifier = "/forums"
+    name = "Forums"
+    weight = 30
 
-[[menu.main]]
-  parent = "/forums"
-  url = "https://researchsoftware.org/council.html"
-  name = "International Council of RSE Associations"
-  weight = 34
+    [[menu.main]]
+      parent = "/forums"
+      url = "/funders-forum"
+      name = "Funders Forum"
+      weight = 31
+
+    [[menu.main]]
+      parent = "/forums"
+      url = "/RSI-forum"
+      name = "Research Software Infrastructure Forum"
+      weight = 32
+
+    [[menu.main]]
+      parent = "/forums"
+      url = "https://adore.software/"
+      name = "ADORE.software Secretariat"
+      weight = 33
+
+    [[menu.main]]
+      parent = "/forums"
+      url = "https://researchsoftware.org/council.html"
+      name = "International Council of RSE Associations"
+      weight = 34
+      
+    [[menu.main]]
+      parent = "/forums"
+      url = "/community-forum"
+      name = "Community Leaders Forum"
+      weight = 35
+
+  [[menu.main]]
+    identifier = "/resa-resources"
+    url = "/resa-resources"
+    name = "Resources"
+    weight = 40
+
+    [[menu.main]]
+      parent = "/resa-resources"
+      name = "Resources"
+      url = "/resa-resources"
+      weight = 41
+
+    [[menu.main]]
+      parent = "/resa-resources"
+      name = "Guidelines"
+      url = "/guidelines"
+      weight = 42
+
+    [[menu.main]]
+      parent = "/resa-resources"
+      name = "Funding Opportunities"
+      url = "/funding-opportunities"
+      weight = 43
+      
+    [[menu.main]]
+      parent = "/resa-resources"
+      name = "Software Policies"
+      url = "/software-policies"
+      weight = 44
+
+    [[menu.main]]
+      parent = "/resa-resources"
+      name = "ADORE.software Declaration"
+      url = "https://adore.software/"
+      weight = 45
+
+    [[menu.main]]
+      parent = "/resa-resources"
+      name = "Research Software Engineers (RSEs)"
+      url = "/research-software-engineers"
+      weight = 46  
   
-[[menu.main]]
-  parent = "/forums"
-  url = "/community-forum"
-  name = "Community Leaders Forum"
-  weight = 35
+  [[menu.main]]
+    url = "/news"
+    name = "News"
+    weight = 50
 
-[[menu.main]]
-  identifier = "/resa-resources"
-  url = "/resa-resources"
-  name = "Resources"
-  weight = 40
+  [[menu.main]]
+    url = "/events"
+    name = "Events"
+    weight = 60
 
-[[menu.main]]
-  parent = "/resa-resources"
-  name = "Resources"
-  url = "/resa-resources"
-  weight = 41
-
-[[menu.main]]
-  parent = "/resa-resources"
-  name = "Guidelines"
-  url = "/guidelines"
-  weight = 42
-
-[[menu.main]]
-  parent = "/resa-resources"
-  name = "Funding Opportunities"
-  url = "/funding-opportunities"
-  weight = 43
-  
-[[menu.main]]
-  parent = "/resa-resources"
-  name = "Software Policies"
-  url = "/software-policies"
-  weight = 44
-
-[[menu.main]]
-  parent = "/resa-resources"
-  name = "ADORE.software Declaration"
-  url = "https://adore.software/"
-  weight = 45
-
-[[menu.main]]
-  parent = "/resa-resources"
-  name = "Research Software Engineers (RSEs)"
-  url = "/research-software-engineers"
-  weight = 46  
-  
-[[menu.main]]
-  url = "/news"
-  name = "News"
-  weight = 50
-
-[[menu.main]]
-  url = "/events"
-  name = "Events"
-  weight = 60
-
-[[menu.main]]
-    url = "/blog"
-    name = "Blog"
-    weight = 70
+  [[menu.main]]
+      url = "/blog"
+      name = "Blog"
+      weight = 70
 
 [[menu.footer_social]]
   weight = 30

--- a/content/membership/30-table-costs.md
+++ b/content/membership/30-table-costs.md
@@ -1,90 +1,13 @@
 +++
-fragment = "table"
-#disabled = false
+title = "Annual Investment"
 date = "2022-09-06"
 weight = 30
-background = "white"
-
-title = "Annual Investment"
-title_align = "left" # Default is center, can be left, right or center
-
-[header]
-  [[header.values]]
-    text = "Number of employees"
-
-  [[header.values]]
-    text = "High Income Country - Not-For-Profit (USD$)"
-
-  [[header.values]]
-    text = "High Income Country - For-Profit (USD$)"
-    
-  [[header.values]]
-    text = "Low/Middle Income Country - Not-For-Profit (USD$)"
-
-  [[header.values]]
-    text = "Low/Middle Income Country - For-Profit (USD$)"
-
-[[rows]]
-  [[rows.values]]
-    text = "less than 150"
-     align = "right"
-    
-  [[rows.values]]
-    text = "$2,500"
-    align = "right"
-    
-  [[rows.values]]
-    text = "$4,000"
-    align = "right"
-
-  [[rows.values]]
-    text = "$500"
-    align = "right"
-
-  [[rows.values]]
-    text = "$800"
-    align = "right"
-
-[[rows]] 
-    [[rows.values]]
-    text = "151-250"
-     align = "right"
-    
-  [[rows.values]]
-    text = "$5,000"
-    align = "right"
-    
-  [[rows.values]]
-    text = "$8,000"
-    align = "right"
-
-  [[rows.values]]
-    text = "$1,000"
-    align = "right"
-
-  [[rows.values]]
-    text = "$1,600"
-    align = "right"
-
-[[rows]]   
-    [[rows.values]]
-    text = "250 or more"
-    align = "right"
-    
-  [[rows.values]]
-    text = "$12,500"
-    align = "right"
-    
-  [[rows.values]]
-    text = "$20,000"
-    align = "right"
-
-  [[rows.values]]
-    text = "$2,500"
-    align = "right"
-
-  [[rows.values]]
-    text = "$4,000"
-    align = "right"
-    
 +++
+
+## Annual Investment
+
+| Number of employees | High Income Country - Not-For-Profit (USD$) | High Income Country - For-Profit (USD$) | Low/Middle Income Country - Not-For-Profit (USD$) | Low/Middle Income Country - For-Profit (USD$) |
+|-----------|-------------|----------------|--------------------|---------------------|
+| less than 150 | $2,500 | $4,000 | $500  | $800|
+| 151-250 | $5,000 | $8,000  | $1,000  | $1,600  |
+| 250 or more   | $12,500  | $20,000 | $2,500 | $4,000 |

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,0 +1,27 @@
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 20px 0;
+    border: 1px solid black;
+    /* Ensures table has an outer border */
+}
+
+th,
+td {
+    border: 1px solid black;
+    /* Black borders for table cells */
+    padding: 8px;
+    text-align: left;
+}
+
+th {
+    background-color: #f2f2f2;
+    /* Light grey background for headers */
+}
+
+body {
+    background-color: #ffffff !important;
+    /* Force white background */
+    color: #000000;
+    /* Optional: Ensure text is visible on white */
+}


### PR DESCRIPTION
In this PR, I have added the necessary CSS file to render markdown tables on the UI. I have also added a line in the file `config.toml` to link to this `custom.css` file present in the `static/css/` folder.

The indentation for the different dropdown pages has also been changed. However, this has no visible effect on the UI.