### PR TITLE
remove extra text from title #36

### DIFF
--- a/content/about-resa/75-om.md
+++ b/content/about-resa/75-om.md
@@ -4,6 +4,6 @@ date = "2022-04-19"
 weight = 75
 background = "secondary"
 
-title = "[Organisational Members](../membership/)"
+title = "Organisational Members"
 +++
 


### PR DESCRIPTION
For issue #36 I have removed extra text from the title for the 'Founding Members' section of the page About/About.